### PR TITLE
Update sponsorship section in release-drafter.yaml (updatecli#8121)

### DIFF
--- a/pkg/core/cache/source.go
+++ b/pkg/core/cache/source.go
@@ -1,0 +1,103 @@
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/resource"
+)
+
+// SourceEntry stores the cached result of a source execution.
+// Transformers are not included — they are re-applied on cache hit so that
+// sources sharing the same underlying resource config but different transformer
+// chains each get the correctly transformed output.
+type SourceEntry struct {
+	Information string // Raw value returned by the plugin, before transformers
+	Description string
+	Result      string // SUCCESS / FAILURE / etc.
+}
+
+// SourceCache is a thread-safe in-memory cache for source execution results,
+// keyed by SHA256 of the sanitized resource configuration.
+// The cache lives for the duration of one updatecli execution and is shared
+// across all pipelines, allowing identical sources to be executed only once.
+//
+// NOTE: today pipelines run sequentially and DAG nodes are serialized by a
+// mutex, so concurrent cache misses for the same key cannot happen. If pipeline
+// execution is ever parallelized, consider adding a singleflight.Group to
+// coalesce concurrent lookups for the same key.
+type SourceCache struct {
+	mu      sync.RWMutex
+	entries map[string]SourceEntry
+}
+
+// NewSourceCache creates a new empty source cache.
+func NewSourceCache() *SourceCache {
+	return &SourceCache{
+		entries: make(map[string]SourceEntry),
+	}
+}
+
+// cacheKeyInput contains only the fields that determine what a source plugin
+// returns. Name, Transformers, DependsOn, and SCMID are excluded so that
+// sources with identical plugin config share the same cache entry regardless
+// of how they are named or wired in different pipelines.
+type cacheKeyInput struct {
+	Kind string `json:"kind"`
+	Spec any    `json:"spec"`
+}
+
+// Key computes a cache key from a ResourceConfig by hashing only the Kind and
+// sanitized Spec (via ReportConfig). This instantiates the resource plugin
+// internally; on a cache miss the caller will instantiate it again for
+// execution. Returns empty string when hashing fails; callers treat that as a
+// cache miss.
+func Key(rc resource.ResourceConfig) string {
+	r, err := resource.New(rc)
+	if err != nil {
+		logrus.Debugf("source cache: failed to instantiate resource for key: %v", err)
+		return ""
+	}
+
+	data, err := json.Marshal(cacheKeyInput{
+		Kind: rc.Kind,
+		Spec: r.ReportConfig(),
+	})
+	if err != nil {
+		logrus.Debugf("source cache: failed to marshal config for key: %v", err)
+		return ""
+	}
+
+	return fmt.Sprintf("%x", sha256.Sum256(data))
+}
+
+// Get retrieves a cached source entry. Returns the entry and true if found.
+func (c *SourceCache) Get(key string) (SourceEntry, bool) {
+	if key == "" {
+		return SourceEntry{}, false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.entries[key]
+	return entry, ok
+}
+
+// Set stores a source entry in the cache.
+func (c *SourceCache) Set(key string, entry SourceEntry) {
+	if key == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = entry
+}
+
+// Len returns the number of entries currently held in the cache.
+func (c *SourceCache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}

--- a/pkg/core/cache/source_test.go
+++ b/pkg/core/cache/source_test.go
@@ -1,0 +1,233 @@
+package cache
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/resource"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/shell"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/shell/success/exitcode"
+)
+
+func TestNewSourceCache(t *testing.T) {
+	// Arrange / Act
+	c := NewSourceCache()
+
+	// Assert
+	require.NotNil(t, c)
+	assert.Equal(t, 0, c.Len())
+}
+
+func TestSourceCache_GetSet(t *testing.T) {
+	// Arrange
+	c := NewSourceCache()
+	key := "some-cache-key"
+	want := SourceEntry{
+		Information: "v1.2.3",
+		Description: "latest stable release",
+		Result:      "SUCCESS",
+	}
+
+	// Act
+	c.Set(key, want)
+	got, ok := c.Get(key)
+
+	// Assert
+	require.True(t, ok)
+	assert.Equal(t, want.Information, got.Information)
+	assert.Equal(t, want.Description, got.Description)
+	assert.Equal(t, want.Result, got.Result)
+}
+
+func TestSourceCache_GetMiss(t *testing.T) {
+	// Arrange
+	c := NewSourceCache()
+
+	// Act
+	got, ok := c.Get("nonexistent-key")
+
+	// Assert
+	assert.False(t, ok)
+	assert.Equal(t, SourceEntry{}, got)
+}
+
+func TestSourceCache_EmptyKey(t *testing.T) {
+	// Arrange
+	c := NewSourceCache()
+	entry := SourceEntry{
+		Information: "some-value",
+		Result:      "SUCCESS",
+	}
+
+	// Act: Set with empty key must be a no-op
+	c.Set("", entry)
+
+	// Assert: nothing was stored
+	assert.Equal(t, 0, c.Len())
+
+	// Act: Get with empty key must return false without panicking
+	got, ok := c.Get("")
+
+	// Assert
+	assert.False(t, ok)
+	assert.Equal(t, SourceEntry{}, got)
+}
+
+func TestSourceCache_Overwrite(t *testing.T) {
+	// Arrange
+	c := NewSourceCache()
+	key := "shared-key"
+	first := SourceEntry{Information: "v1.0.0", Result: "SUCCESS"}
+	second := SourceEntry{Information: "v2.0.0", Result: "SUCCESS"}
+
+	// Act: write the same key twice
+	c.Set(key, first)
+	c.Set(key, second)
+	got, ok := c.Get(key)
+
+	// Assert: only the latest value is returned
+	require.True(t, ok)
+	assert.Equal(t, second.Information, got.Information)
+	assert.Equal(t, 1, c.Len(), "overwriting an existing key must not grow the cache")
+}
+
+func TestSourceCache_Len(t *testing.T) {
+	// Arrange
+	c := NewSourceCache()
+	entries := map[string]SourceEntry{
+		"alpha": {Information: "1", Result: "SUCCESS"},
+		"beta":  {Information: "2", Result: "SUCCESS"},
+		"gamma": {Information: "3", Result: "FAILURE"},
+	}
+
+	// Act
+	for k, v := range entries {
+		c.Set(k, v)
+	}
+
+	// Assert
+	assert.Equal(t, len(entries), c.Len())
+}
+
+// TestSourceCache_ConcurrentAccess verifies that concurrent reads and writes
+// do not trigger the race detector.
+func TestSourceCache_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	c := NewSourceCache()
+	const workers = 20
+	const opsPerWorker = 50
+
+	var wg sync.WaitGroup
+	wg.Add(workers * 2)
+
+	for i := range workers {
+		go func(i int) {
+			defer wg.Done()
+			for j := range opsPerWorker {
+				key := "key-odd"
+				if j%2 == 0 {
+					key = "key-even"
+				}
+				c.Set(key, SourceEntry{
+					Information: "value",
+					Result:      "SUCCESS",
+				})
+				_ = i
+			}
+		}(i)
+	}
+
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for range opsPerWorker {
+				c.Get("key-even")
+				c.Len()
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestKey_EmptyKind verifies that Key returns an empty string when the
+// ResourceConfig has no Kind. GetReportConfig cannot resolve an unknown plugin,
+// so Key returns the empty-string sentinel that callers treat as a cache miss.
+func TestKey_EmptyKind(t *testing.T) {
+	// Arrange
+	rc := resource.ResourceConfig{
+		Kind: "",
+		Name: "my-source",
+	}
+
+	// Act
+	key := Key(rc)
+
+	// Assert
+	assert.Equal(t, "", key)
+}
+
+// shellSpec returns a minimal but fully-formed shell.Spec that resource.New()
+// can instantiate without error, making it suitable as a Key() input.
+func shellSpec(command string) shell.Spec {
+	return shell.Spec{
+		Command: command,
+		ChangedIf: shell.SpecChangedIf{
+			Kind: "exitcode",
+			Spec: exitcode.Spec{Warning: 1, Success: 0, Failure: 2},
+		},
+	}
+}
+
+// TestKey_SameConfigProducesSameKey verifies the key is stable across two calls
+// with identical config values.
+func TestKey_SameConfigProducesSameKey(t *testing.T) {
+	// Arrange: a fully-formed config that resource.New() can resolve.
+	rc := resource.ResourceConfig{
+		Kind: "shell",
+		Name: "my-source",
+		Spec: shellSpec("echo hello"),
+	}
+
+	// Act
+	key1 := Key(rc)
+	key2 := Key(rc)
+
+	// Assert
+	require.NotEmpty(t, key1)
+	assert.Equal(t, key1, key2)
+}
+
+// TestKey_SameSpecDifferentNamesShareKey verifies that two configs with
+// identical Kind+Spec but different Names produce the same key.
+func TestKey_SameSpecDifferentNamesShareKey(t *testing.T) {
+	spec := shellSpec("echo hello")
+	rc1 := resource.ResourceConfig{Kind: "shell", Name: "name-a", Spec: spec}
+	rc2 := resource.ResourceConfig{Kind: "shell", Name: "name-b", Spec: spec}
+
+	key1 := Key(rc1)
+	key2 := Key(rc2)
+
+	require.NotEmpty(t, key1)
+	assert.Equal(t, key1, key2)
+}
+
+// TestKey_DifferentSpecsProduceDifferentKeys verifies that two configs with
+// different Spec values produce distinct keys.
+func TestKey_DifferentSpecsProduceDifferentKeys(t *testing.T) {
+	// Arrange
+	rc1 := resource.ResourceConfig{Kind: "shell", Name: "source-a", Spec: shellSpec("echo a")}
+	rc2 := resource.ResourceConfig{Kind: "shell", Name: "source-b", Spec: shellSpec("echo b")}
+
+	// Act
+	key1 := Key(rc1)
+	key2 := Key(rc2)
+
+	// Assert
+	require.NotEmpty(t, key1)
+	require.NotEmpty(t, key2)
+	assert.NotEqual(t, key1, key2)
+}

--- a/pkg/core/engine/main.go
+++ b/pkg/core/engine/main.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"errors"
 
+	"github.com/updatecli/updatecli/pkg/core/cache"
 	"github.com/updatecli/updatecli/pkg/core/config"
 	"github.com/updatecli/updatecli/pkg/core/pipeline"
 	"github.com/updatecli/updatecli/pkg/core/reports"
@@ -22,6 +23,7 @@ type Engine struct {
 	Options        Options
 	Reports        reports.Reports
 	tracer         trace.Tracer
+	sourceCache    *cache.SourceCache
 }
 
 // SetTracer configures the tracer used for OTel instrumentation across all engine operations.

--- a/pkg/core/engine/run.go
+++ b/pkg/core/engine/run.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/cache"
+	"github.com/updatecli/updatecli/pkg/core/httpclient"
 	"github.com/updatecli/updatecli/pkg/core/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -31,6 +32,9 @@ func (e *Engine) Run(ctx context.Context) (err error) {
 	if e.sourceCache == nil {
 		e.sourceCache = cache.NewSourceCache()
 	}
+
+	httpclient.EnableHTTPCache()
+	defer httpclient.DisableHTTPCache()
 
 	for i := range e.Pipelines {
 		pipeline := e.Pipelines[i]

--- a/pkg/core/engine/run.go
+++ b/pkg/core/engine/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/cache"
 	"github.com/updatecli/updatecli/pkg/core/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -27,8 +28,13 @@ func (e *Engine) Run(ctx context.Context) (err error) {
 
 	errs := []error{}
 
+	if e.sourceCache == nil {
+		e.sourceCache = cache.NewSourceCache()
+	}
+
 	for i := range e.Pipelines {
 		pipeline := e.Pipelines[i]
+		pipeline.SourceCache = e.sourceCache
 
 		err := pipeline.Run(ctx)
 		if err != nil {

--- a/pkg/core/httpclient/caching.go
+++ b/pkg/core/httpclient/caching.go
@@ -1,0 +1,90 @@
+package httpclient
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// cachedResponse stores the essential parts of an HTTP response for replay.
+type cachedResponse struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+}
+
+// cachingTransport is an http.RoundTripper that caches successful GET responses
+// in memory. Non-GET requests and non-2xx responses are passed through uncached.
+type cachingTransport struct {
+	transport http.RoundTripper
+	mu        sync.RWMutex
+	entries   map[string]cachedResponse
+}
+
+func newCachingTransport(transport http.RoundTripper) *cachingTransport {
+	return &cachingTransport{
+		transport: transport,
+		entries:   make(map[string]cachedResponse),
+	}
+}
+
+func (c *cachingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method != http.MethodGet {
+		return c.transport.RoundTrip(req)
+	}
+
+	key := req.URL.String()
+
+	c.mu.RLock()
+	entry, ok := c.entries[key]
+	c.mu.RUnlock()
+
+	if ok {
+		logrus.Debugf("http cache hit: %s", key)
+		return &http.Response{
+			StatusCode: entry.StatusCode,
+			Header:     entry.Header.Clone(),
+			Body:       io.NopCloser(bytes.NewReader(entry.Body)),
+			Request:    req,
+		}, nil
+	}
+
+	resp, err := c.transport.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	// Only cache 2xx responses so callers still see errors and redirects normally.
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			resp.Body.Close()
+			return nil, readErr
+		}
+		resp.Body.Close()
+
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+
+		c.mu.Lock()
+		c.entries[key] = cachedResponse{
+			StatusCode: resp.StatusCode,
+			Header:     resp.Header.Clone(),
+			Body:       body,
+		}
+		c.mu.Unlock()
+
+		logrus.Debugf("http cache store: %s", key)
+	}
+
+	return resp, nil
+}
+
+// Len returns the number of cached responses (for testing).
+func (c *cachingTransport) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}

--- a/pkg/core/httpclient/caching_test.go
+++ b/pkg/core/httpclient/caching_test.go
@@ -1,0 +1,267 @@
+package httpclient
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newCountingServer returns a test server that increments a hit counter on every
+// request and responds with the provided handler. The counter pointer is safe to
+// read after the server is closed.
+func newCountingServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		handler(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+func TestCachingTransport_CachesGetRequests(t *testing.T) {
+	// Arrange
+	srv, hits := newCountingServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello cache"))
+	})
+
+	ct := newCachingTransport(http.DefaultTransport)
+	client := &http.Client{Transport: ct}
+
+	// Act
+	resp1, err := client.Get(srv.URL + "/resource")
+	require.NoError(t, err)
+	body1, err := io.ReadAll(resp1.Body)
+	require.NoError(t, err)
+	resp1.Body.Close()
+
+	resp2, err := client.Get(srv.URL + "/resource")
+	require.NoError(t, err)
+	body2, err := io.ReadAll(resp2.Body)
+	require.NoError(t, err)
+	resp2.Body.Close()
+
+	// Assert
+	assert.Equal(t, int64(1), hits.Load(), "server should be hit exactly once")
+	assert.Equal(t, "hello cache", string(body1))
+	assert.Equal(t, "hello cache", string(body2))
+	assert.Equal(t, 1, ct.Len())
+}
+
+func TestCachingTransport_SkipsNonGetMethods(t *testing.T) {
+	// Arrange
+	srv, hits := newCountingServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ct := newCachingTransport(http.DefaultTransport)
+	client := &http.Client{Transport: ct}
+
+	// Act
+	for i := 0; i < 2; i++ {
+		resp, err := client.Post(srv.URL+"/submit", "application/json", nil)
+		require.NoError(t, err)
+		resp.Body.Close()
+	}
+
+	// Assert
+	assert.Equal(t, int64(2), hits.Load(), "non-GET requests must never be served from cache")
+	assert.Equal(t, 0, ct.Len())
+}
+
+func TestCachingTransport_SkipsNon2xxResponses(t *testing.T) {
+	// Arrange
+	srv, hits := newCountingServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	ct := newCachingTransport(http.DefaultTransport)
+	client := &http.Client{Transport: ct}
+
+	// Act
+	for i := 0; i < 2; i++ {
+		resp, err := client.Get(srv.URL + "/missing")
+		require.NoError(t, err)
+		resp.Body.Close()
+	}
+
+	// Assert
+	assert.Equal(t, int64(2), hits.Load(), "non-2xx responses must not be cached")
+	assert.Equal(t, 0, ct.Len())
+}
+
+func TestCachingTransport_DifferentURLsDifferentEntries(t *testing.T) {
+	// Arrange
+	srv, _ := newCountingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "body for %s", r.URL.Path)
+	})
+
+	ct := newCachingTransport(http.DefaultTransport)
+	client := &http.Client{Transport: ct}
+
+	// Act
+	resp1, err := client.Get(srv.URL + "/alpha")
+	require.NoError(t, err)
+	body1, err := io.ReadAll(resp1.Body)
+	require.NoError(t, err)
+	resp1.Body.Close()
+
+	resp2, err := client.Get(srv.URL + "/beta")
+	require.NoError(t, err)
+	body2, err := io.ReadAll(resp2.Body)
+	require.NoError(t, err)
+	resp2.Body.Close()
+
+	// Assert
+	assert.Equal(t, 2, ct.Len())
+	assert.Equal(t, "body for /alpha", string(body1))
+	assert.Equal(t, "body for /beta", string(body2))
+}
+
+func TestCachingTransport_CachedResponseHasCorrectHeaders(t *testing.T) {
+	// Arrange
+	srv, hits := newCountingServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Custom", "my-value")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	ct := newCachingTransport(http.DefaultTransport)
+	client := &http.Client{Transport: ct}
+
+	// Act — first request populates the cache
+	resp1, err := client.Get(srv.URL + "/data")
+	require.NoError(t, err)
+	io.ReadAll(resp1.Body) //nolint:errcheck
+	resp1.Body.Close()
+
+	// Act — second request is served from cache
+	resp2, err := client.Get(srv.URL + "/data")
+	require.NoError(t, err)
+	io.ReadAll(resp2.Body) //nolint:errcheck
+	resp2.Body.Close()
+
+	// Assert
+	assert.Equal(t, int64(1), hits.Load())
+	assert.Equal(t, "application/json", resp2.Header.Get("Content-Type"))
+	assert.Equal(t, "my-value", resp2.Header.Get("X-Custom"))
+}
+
+func TestCachingTransport_CachedBodyIsReReadable(t *testing.T) {
+	// Arrange
+	srv, hits := newCountingServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("rereadable body"))
+	})
+
+	ct := newCachingTransport(http.DefaultTransport)
+	client := &http.Client{Transport: ct}
+
+	var bodies [3]string
+
+	// Act — three reads of the same URL
+	for i := 0; i < 3; i++ {
+		resp, err := client.Get(srv.URL + "/item")
+		require.NoError(t, err)
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		resp.Body.Close()
+		bodies[i] = string(b)
+	}
+
+	// Assert
+	assert.Equal(t, int64(1), hits.Load(), "server should be hit exactly once across three reads")
+	assert.Equal(t, "rereadable body", bodies[0])
+	assert.Equal(t, bodies[0], bodies[1])
+	assert.Equal(t, bodies[1], bodies[2])
+}
+
+func TestEnableDisableHTTPCache(t *testing.T) {
+	// Restore default state after the test regardless of outcome.
+	t.Cleanup(DisableHTTPCache)
+
+	// Arrange — a server that counts every request it receives.
+	srv, hits := newCountingServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	// Act — client created while caching is enabled.
+	EnableHTTPCache()
+	cachedClient := NewRetryClient()
+
+	// Hit the endpoint twice; the second call must be served from cache.
+	for i := 0; i < 2; i++ {
+		resp, err := cachedClient.Get(srv.URL + "/ping")
+		require.NoError(t, err)
+		io.ReadAll(resp.Body) //nolint:errcheck
+		resp.Body.Close()
+	}
+
+	// Assert — only one real network request expected.
+	assert.Equal(t, int64(1), hits.Load(), "caching client should hit the server exactly once")
+
+	// Act — disable caching and create a new client; it must not cache.
+	DisableHTTPCache()
+	plainClient := NewRetryClient()
+
+	for i := 0; i < 2; i++ {
+		resp, err := plainClient.Get(srv.URL + "/ping")
+		require.NoError(t, err)
+		io.ReadAll(resp.Body) //nolint:errcheck
+		resp.Body.Close()
+	}
+
+	// Assert — two additional hits means no caching.
+	assert.Equal(t, int64(3), hits.Load(), "plain client should not use cache, expecting 3 total hits")
+}
+
+func TestCachingTransport_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	srv, hits := newCountingServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("concurrent"))
+	})
+
+	ct := newCachingTransport(http.DefaultTransport)
+	client := &http.Client{Transport: ct}
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	// Act — all goroutines race to GET the same URL.
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			resp, err := client.Get(srv.URL + "/shared")
+			if err != nil {
+				return
+			}
+			io.ReadAll(resp.Body) //nolint:errcheck
+			resp.Body.Close()
+		}()
+	}
+	wg.Wait()
+
+	// Assert — at most one real request (cache wins the race), never more than
+	// the number of goroutines (safety upper bound), and no data race detected
+	// by the Go race detector.
+	serverHits := hits.Load()
+	assert.GreaterOrEqual(t, serverHits, int64(1))
+	assert.LessOrEqual(t, serverHits, int64(goroutines))
+	assert.Equal(t, 1, ct.Len())
+}

--- a/pkg/core/httpclient/transport.go
+++ b/pkg/core/httpclient/transport.go
@@ -2,13 +2,47 @@ package httpclient
 
 import (
 	"net/http"
+	"sync"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
+var (
+	cacheMu     sync.Mutex
+	activeCache *cachingTransport
+)
+
+// EnableHTTPCache activates in-memory caching of GET responses for all
+// HTTP clients created via this package after this call.
+// Call once before pipeline execution begins.
+func EnableHTTPCache() {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	activeCache = newCachingTransport(otelhttp.NewTransport(&http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}))
+}
+
+// DisableHTTPCache deactivates the HTTP cache and releases cached data.
+// Safe to call even if caching was never enabled.
+func DisableHTTPCache() {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	activeCache = nil
+}
+
 // DefaultTransport returns a RoundTripper with retry and proxy support.
-// Use when a third-party library needs a transport rather than a full http.Client.
+// When HTTP caching is enabled via EnableHTTPCache, GET responses are served
+// from cache: retryTransport -> cachingTransport -> otelhttp -> http.Transport.
 func DefaultTransport() http.RoundTripper {
+	cacheMu.Lock()
+	inner := activeCache
+	cacheMu.Unlock()
+
+	if inner != nil {
+		return &retryTransport{transport: inner}
+	}
+
 	return &retryTransport{
 		transport: otelhttp.NewTransport(&http.Transport{
 			Proxy: http.ProxyFromEnvironment,

--- a/pkg/core/pipeline/main.go
+++ b/pkg/core/pipeline/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/heimdalr/dag"
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/cache"
 	"github.com/updatecli/updatecli/pkg/core/config"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/action"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/condition"
@@ -48,6 +49,9 @@ type Pipeline struct {
 	mu     sync.Mutex
 	// CrawlerKind identifies the autodiscovery crawler that generated this pipeline (empty for user-defined pipelines).
 	CrawlerKind string
+	// SourceCache is a shared in-memory cache for source execution results,
+	// injected by the engine before the pipeline runs.
+	SourceCache *cache.SourceCache
 	tracer      trace.Tracer
 }
 

--- a/pkg/core/pipeline/source/main.go
+++ b/pkg/core/pipeline/source/main.go
@@ -11,6 +11,7 @@ import (
 	jschema "github.com/invopop/jsonschema"
 	"github.com/sirupsen/logrus"
 
+	"github.com/updatecli/updatecli/pkg/core/cache"
 	"github.com/updatecli/updatecli/pkg/core/jsonschema"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/resource"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
@@ -42,7 +43,7 @@ var (
 )
 
 // Run execute actions defined by the source configuration
-func (s *Source) Run(ctx context.Context) (err error) {
+func (s *Source) Run(ctx context.Context, sourceCache *cache.SourceCache) (err error) {
 
 	var consoleOutput bytes.Buffer
 	// By default logrus logs to stderr, so I guess we want to keep this behavior...
@@ -56,44 +57,58 @@ func (s *Source) Run(ctx context.Context) (err error) {
 	defer logrus.SetOutput(os.Stdout)
 	defer s.Result.SetConsoleOutput(&consoleOutput)
 
-	source, err := resource.New(s.Config.ResourceConfig)
-	if err != nil {
-		s.Result.Result = result.FAILURE
-		return err
+	cacheKey := cache.Key(s.Config.ResourceConfig)
+	cacheHit := false
+
+	if sourceCache != nil {
+		if entry, ok := sourceCache.Get(cacheKey); ok {
+			logrus.Infof("source cache hit for %q", s.Config.Name)
+			s.Result.Information = entry.Information
+			s.Result.Description = entry.Description
+			s.Result.Result = entry.Result
+			cacheHit = true
+		}
 	}
 
-	workingDir := ""
-
-	switch s.Scm == nil {
-	case true:
-		pwd, err := os.Getwd()
+	if !cacheHit {
+		source, err := resource.New(s.Config.ResourceConfig)
 		if err != nil {
 			s.Result.Result = result.FAILURE
 			return err
 		}
 
-		workingDir = pwd
-	case false:
-		SCM := *s.Scm
+		workingDir := ""
 
-		err = SCM.Checkout()
+		switch s.Scm == nil {
+		case true:
+			pwd, err := os.Getwd()
+			if err != nil {
+				s.Result.Result = result.FAILURE
+				return err
+			}
+
+			workingDir = pwd
+		case false:
+			SCM := *s.Scm
+
+			err = SCM.Checkout()
+			if err != nil {
+				s.Result.Result = result.FAILURE
+				return err
+			}
+
+			workingDir = SCM.GetDirectory()
+		}
+
+		err = source.Source(ctx, workingDir, s.Result)
 		if err != nil {
 			s.Result.Result = result.FAILURE
 			return err
 		}
-
-		workingDir = SCM.GetDirectory()
 	}
-
-	err = source.Source(ctx, workingDir, s.Result)
 
 	s.Output = s.Result.Information
 	s.OriginalOutput = s.Result.Information
-
-	if err != nil {
-		s.Result.Result = result.FAILURE
-		return err
-	}
 
 	logrus.Infof("%s %s", s.Result.Result, s.Result.Description)
 
@@ -103,6 +118,14 @@ func (s *Source) Run(ctx context.Context) (err error) {
 			s.Result.Result = result.FAILURE
 			return err
 		}
+	}
+
+	if !cacheHit && sourceCache != nil && s.Result.Result == result.SUCCESS {
+		sourceCache.Set(cacheKey, cache.SourceEntry{
+			Information: s.Result.Information,
+			Description: s.Result.Description,
+			Result:      s.Result.Result,
+		})
 	}
 
 	if len(s.Output) == 0 && s.Result.Result == result.SUCCESS {

--- a/pkg/core/pipeline/sources.go
+++ b/pkg/core/pipeline/sources.go
@@ -13,7 +13,7 @@ func (p *Pipeline) RunSource(ctx context.Context, id string) (r string, err erro
 	source.Config = p.Config.Spec.Sources[id]
 	source.Result.Name = source.Config.Name
 
-	err = source.Run(ctx)
+	err = source.Run(ctx, p.SourceCache)
 
 	p.Sources[id] = source
 

--- a/pkg/core/pipeline/sources_test.go
+++ b/pkg/core/pipeline/sources_test.go
@@ -2,9 +2,14 @@ package pipeline
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/cache"
 	"github.com/updatecli/updatecli/pkg/core/config"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/condition"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/resource"
@@ -233,4 +238,114 @@ func TestRunSources(t *testing.T) {
 		})
 	}
 
+}
+
+// TestRunSource_CacheMiss verifies that when the SourceCache has no entry,
+// the source executes normally and writes its result to the cache.
+func TestRunSource_CacheMiss(t *testing.T) {
+	sourceID := "my-source"
+	conf := config.Config{
+		Spec: config.Spec{
+			Name: "cache-miss pipeline",
+			Sources: map[string]source.Config{
+				sourceID: {
+					ResourceConfig: resource.ResourceConfig{
+						Kind: "shell",
+						Name: sourceID,
+						Spec: shell.Spec{
+							Command: "echo hello",
+							ChangedIf: shell.SpecChangedIf{
+								Kind: "exitcode",
+								Spec: exitcode.Spec{Warning: 1, Success: 0, Failure: 2},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p := Pipeline{}
+	require.NoError(t, p.Init(&conf, Options{}))
+
+	sc := cache.NewSourceCache()
+	p.SourceCache = sc
+
+	err := p.Run(context.Background())
+	require.NoError(t, err)
+
+	src := p.Sources[sourceID]
+	assert.Equal(t, result.SUCCESS, src.Result.Result)
+	assert.Equal(t, "hello", src.Result.Information)
+
+	// Cache must have been populated with exactly one entry.
+	assert.Equal(t, 1, sc.Len(), "cache must contain an entry after a successful source run")
+}
+
+// TestRunSource_CacheHit verifies that when a second pipeline reuses the same
+// source config, the cache prevents re-execution. A temp file counter proves
+// the shell command ran exactly once across two pipeline runs.
+func TestRunSource_CacheHit(t *testing.T) {
+	counterFile := filepath.Join(t.TempDir(), "counter")
+	require.NoError(t, os.WriteFile(counterFile, []byte("0"), 0o644))
+
+	// Shell command: increment counter file and echo a value.
+	command := fmt.Sprintf(
+		`count=$(cat %s); count=$((count+1)); echo $count > %s; echo hello`,
+		counterFile, counterFile,
+	)
+
+	sourceID := "my-source"
+	sourceCfg := source.Config{
+		ResourceConfig: resource.ResourceConfig{
+			Kind: "shell",
+			Name: sourceID,
+			Spec: shell.Spec{
+				Command: command,
+				ChangedIf: shell.SpecChangedIf{
+					Kind: "exitcode",
+					Spec: exitcode.Spec{Warning: 1, Success: 0, Failure: 2},
+				},
+			},
+		},
+	}
+
+	sc := cache.NewSourceCache()
+
+	// First run: executes the shell command, populates the cache.
+	conf1 := config.Config{
+		Spec: config.Spec{
+			Name: "first pipeline",
+			Sources: map[string]source.Config{sourceID: sourceCfg},
+		},
+	}
+	p1 := Pipeline{}
+	require.NoError(t, p1.Init(&conf1, Options{}))
+	p1.SourceCache = sc
+	require.NoError(t, p1.Run(context.Background()))
+	assert.Equal(t, 1, sc.Len(), "first run must populate the cache")
+
+	// Second run with the same cache: should hit, command must NOT run again.
+	conf2 := config.Config{
+		Spec: config.Spec{
+			Name: "second pipeline",
+			Sources: map[string]source.Config{sourceID: sourceCfg},
+		},
+	}
+	p2 := Pipeline{}
+	require.NoError(t, p2.Init(&conf2, Options{}))
+	p2.SourceCache = sc
+	require.NoError(t, p2.Run(context.Background()))
+
+	src := p2.Sources[sourceID]
+	assert.Equal(t, result.SUCCESS, src.Result.Result)
+	assert.Equal(t, "hello", src.Result.Information,
+		"second run must return the cached value")
+	assert.Equal(t, 1, sc.Len())
+
+	// The counter file proves the shell command executed exactly once.
+	data, err := os.ReadFile(counterFile)
+	require.NoError(t, err)
+	assert.Equal(t, "1\n", string(data),
+		"shell command must have executed exactly once across two pipeline runs")
 }


### PR DESCRIPTION
## Summary

Implements a two-layer in-memory caching system to reduce redundant API calls during pipeline execution, as proposed in #8071.

### Layer 1: HTTP Response Cache (`pkg/core/httpclient/`)

A `cachingTransport` wrapping the existing HTTP transport chain caches successful (2xx) GET responses in memory. All plugins benefit automatically since they go through the centralized `httpclient` package — zero plugin changes required.

- Enabled/disabled via `EnableHTTPCache()`/`DisableHTTPCache()` in `Engine.Run()`
- Only caches GET requests with 2xx status codes
- Thread-safe via `sync.RWMutex`

### Layer 2: Source Result Cache (`pkg/core/cache/`)

A `SourceCache` shared across pipelines deduplicates source executions when the same Kind+Spec appears in multiple pipelines (or multiple times within one). The cache key is a SHA256 of only `Kind` + sanitized `Spec` (via `ReportConfig()`), so sources with the same plugin config but different names, transformers, or `dependsOn` share a cache entry.

- Transformers are not cached — they are re-applied on cache hit
- Only successful results are cached
- Injected from `Engine` into each `Pipeline` before execution

### How they complement each other

| Scenario | Layer hit |
|----------|-----------|
| Same Kind+Spec across sources/pipelines | **Source cache** — skips execution entirely |
| Different Spec but same underlying API URL | **HTTP cache** — skips network call, plugin still filters locally |

```
# Single manifest, three sources, one network call:

source: golang-1.23
  http cache store: https://go.dev/dl/?mode=json&include=all   # fresh API call

source: golang-1.22
  http cache hit: https://go.dev/dl/?mode=json&include=all     # different filter, same URL

source: golang-1.23-dup
  source cache hit for "Get Golang 1.23 duplicate"             # same Kind+Spec
```

## Test

To test this pull request, you can run the following commands:

```shell
go test -race ./pkg/core/cache/ ./pkg/core/httpclient/ ./pkg/core/pipeline/ ./pkg/core/engine/
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

- The `cache.Key()` function calls `resource.New()` to obtain `ReportConfig()`, which means the plugin is instantiated twice on a cache miss (once for key, once for execution). This is acceptable for now as plugin constructors are lightweight.
- The `shell` resource kind is cached like any other resource. For sources with side effects, this may need an opt-out mechanism in a future iteration — pending maintainer input.
- HTTP cache keys use the URL string only. Requests to the same URL with different auth headers would share a cache entry, which is correct for updatecli's usage patterns (consistent auth per endpoint within a run).

### Potential improvement

- Add a `singleflight.Group` to coalesce concurrent cache misses for the same key if pipeline execution is ever parallelized.
- Add an opt-out config flag (`nocache: true`) per source for resources with side effects.
- Optimize double `resource.New()` by threading the instantiated resource through the cache key computation.
- Extend caching to conditions (second cache map as described in #8071).
